### PR TITLE
Change: [Network] Encapsulate logic about the connection string to the network code

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -901,8 +901,7 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 	/* Don't resolve the address first, just print it directly as it comes from the config file. */
 	IConsolePrintF(CC_DEFAULT, "Reconnecting to %s ...", _settings_client.network.last_joined);
 
-	NetworkAddress address = ParseConnectionString(_settings_client.network.last_joined, NETWORK_DEFAULT_PORT);
-	NetworkClientConnectGame(address, playas);
+	NetworkClientConnectGame(_settings_client.network.last_joined, playas);
 	return true;
 }
 
@@ -918,23 +917,7 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 	if (argc < 2) return false;
 	if (_networking) NetworkDisconnect(); // we are in network-mode, first close it!
 
-	CompanyID join_as = COMPANY_NEW_COMPANY;
-	NetworkAddress address = ParseGameConnectionString(&join_as, argv[1], NETWORK_DEFAULT_PORT);
-
-	IConsolePrintF(CC_DEFAULT, "Connecting to %s...", address.GetAddressAsString().c_str());
-	if (join_as != COMPANY_NEW_COMPANY) {
-		IConsolePrintF(CC_DEFAULT, "    company-no: %d", join_as);
-
-		/* From a user pov 0 is a new company, internally it's different and all
-		 * companies are offset by one to ease up on users (eg companies 1-8 not 0-7) */
-		if (join_as != COMPANY_SPECTATOR) {
-			if (join_as > MAX_COMPANIES) return false;
-			join_as--;
-		}
-	}
-
-	NetworkClientConnectGame(address, join_as);
-
+	NetworkClientConnectGame(argv[1], COMPANY_NEW_COMPANY);
 	return true;
 }
 

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -12,7 +12,7 @@
 #include "../../stdafx.h"
 #include "../../debug.h"
 #include "../../rev.h"
-#include "../network_func.h"
+#include "../network_internal.h"
 #include "game_info.h"
 
 #include "tcp_http.h"

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -18,7 +18,6 @@
 // #define DEBUG_FAILED_DUMP_COMMANDS
 
 #include "network_type.h"
-#include "core/address.h"
 #include "../console_type.h"
 #include "../gfx_type.h"
 #include "../openttd.h"
@@ -47,14 +46,12 @@ void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 void ParseFullConnectionString(const char **company, const char **port, char *connection_string);
-NetworkAddress ParseConnectionString(const char *connection_string, int default_port);
-NetworkAddress ParseGameConnectionString(CompanyID *company, const char *connection_string, int default_port);
-void NetworkStartDebugLog(NetworkAddress &address);
+void NetworkStartDebugLog(const std::string &connection_string);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
-void NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+void NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const char *msg, int64 data = 0);

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -119,4 +119,8 @@ StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkFindName(char *new_name, const char *last);
 const char *GenerateCompanyPasswordHash(const char *password, const char *password_server_id, uint32 password_game_seed);
 
+void NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+NetworkAddress ParseConnectionString(const std::string &connection_string, int default_port);
+NetworkAddress ParseGameConnectionString(CompanyID *company, const std::string &connection_string, int default_port);
+
 #endif /* NETWORK_INTERNAL_H */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -473,21 +473,10 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		if (_switch_mode != SM_NONE) MakeNewgameSettingsLive();
 
 		if (_network_available && network_conn != nullptr) {
-			CompanyID join_as = COMPANY_NEW_COMPANY;
-			NetworkAddress address = ParseGameConnectionString(&join_as, network_conn, NETWORK_DEFAULT_PORT);
-
-			if (join_as != COMPANY_NEW_COMPANY && join_as != COMPANY_SPECTATOR) {
-				join_as--;
-				if (join_as >= MAX_COMPANIES) {
-					delete this;
-					return;
-				}
-			}
-
 			LoadIntroGame();
 			_switch_mode = SM_NONE;
 
-			NetworkClientConnectGame(address, join_as, join_server_password, join_company_password);
+			NetworkClientConnectGame(network_conn, COMPANY_NEW_COMPANY, join_server_password, join_company_password);
 		}
 
 		/* After the scan we're not used anymore. */
@@ -763,8 +752,7 @@ int openttd_main(int argc, char *argv[])
 	NetworkStartUp(); // initialize network-core
 
 	if (debuglog_conn != nullptr && _network_available) {
-		NetworkAddress address = ParseConnectionString(debuglog_conn, NETWORK_DEFAULT_DEBUGLOG_PORT);
-		NetworkStartDebugLog(address);
+		NetworkStartDebugLog(debuglog_conn);
 	}
 
 	if (!HandleBootstrap()) {
@@ -1476,8 +1464,7 @@ void GameLoop()
 		if (_network_reconnect > 0 && --_network_reconnect == 0) {
 			/* This means that we want to reconnect to the last host
 			 * We do this here, because it means that the network is really closed */
-			NetworkAddress address = ParseConnectionString(_settings_client.network.last_joined, NETWORK_DEFAULT_PORT);
-			NetworkClientConnectGame(address, COMPANY_SPECTATOR);
+			NetworkClientConnectGame(_settings_client.network.last_joined, COMPANY_SPECTATOR);
 		}
 		/* Singleplayer */
 		StateGameLoop();


### PR DESCRIPTION
## Motivation / Problem

Internal knowledge about connection strings leaking out of network code.


## Description

Move decoding logic into network/ files, instead of spreading it over console_cmds.cpp and openttd.cpp.


## Limitations

None, I hope.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
